### PR TITLE
Horizontal_add

### DIFF
--- a/src/ops/f64.rs
+++ b/src/ops/f64.rs
@@ -654,35 +654,23 @@ impl_op! {
     fn horizontal_add<f64> {
         for Avx2(a: __m256d) -> f64 {
             let a = _mm256_hadd_pd(a, a);
-            let b = _mm256_hadd_pd(a, a);
-
-            let first = _mm_cvtsd_f64(_mm256_extractf128_pd(b, 0));
-            let second = _mm_cvtsd_f64(_mm256_extractf128_pd(b, 1));
-
+            let first = _mm_cvtsd_f64(_mm256_extractf128_pd(a, 0));
+            let second = _mm_cvtsd_f64(_mm256_extractf128_pd(a, 1));
             first + second
         }
         for Sse41(a: __m128d) -> f64 {
-            let a = _mm_hadd_pd(a, a);
-
-            let first = _mm_cvtsd_f64(a);
-            let second = _mm_cvtsd_f64(_mm_shuffle_pd(a, a, 1));
-
-            first + second
+             _mm_cvtsd_f64(_mm_hadd_pd(a, a))
         }
         for Sse2(a: __m128d) -> f64 {
             let a = _mm_add_pd(a, _mm_shuffle_pd(a, a, 1));
-
-            let first = _mm_cvtsd_f64(a);
-            let second = _mm_cvtsd_f64(_mm_shuffle_pd(a, a, 1));
-
-            first + second
+            _mm_cvtsd_f64(a)
         }
         for Scalar(a: f64) -> f64 {
             a
         }
         for Neon(a: float64x2_t) -> f64 {
             let a = vpaddq_f64(a, a);
-            vgetq_lane_f64(a, 0) + vgetq_lane_f64(a, 1)
+            vgetq_lane_f64(a, 0)
         }
         for Wasm(a: v128) -> f64 {
             let l0 = f64x2_extract_lane::<0>(a);

--- a/src/tests/lib/numbers.rs
+++ b/src/tests/lib/numbers.rs
@@ -136,10 +136,13 @@ impl ScalarNumber for f32 {
         match precision {
             EqPrecision::Exact => self == other,
             EqPrecision::Almost { figs } => {
+                let epsilon = 10.0f32.powi(-(figs as i32));
+                if (self - other).abs() < epsilon {
+                    return true;
+                }
                 let bigger = self.max(other);
                 let norm_diff = (self / bigger) - (other / bigger);
-                let epsilon = 10.0f32.powi(-(figs as i32));
-                norm_diff < epsilon
+                norm_diff.abs() < epsilon
             }
         }
     }
@@ -189,10 +192,13 @@ impl ScalarNumber for f64 {
         match precision {
             EqPrecision::Exact => self == other,
             EqPrecision::Almost { figs } => {
+                let epsilon = 10.0f64.powi(-(figs as i32));
+                if (self - other).abs() < epsilon {
+                    return true;
+                }
                 let bigger = self.max(other);
                 let norm_diff = (self / bigger) - (other / bigger);
-                let epsilon = 10.0f64.powi(-(figs as i32));
-                norm_diff < epsilon
+                norm_diff.abs() < epsilon
             }
         }
     }


### PR DESCRIPTION
I'm really enjoying this crate, especially the ergonomics of the unified op names in v2. I've been experimenting with the new API in a side project and I noticed that my results for S::Vf64 were double what I expected, and double what the S::Vf32 implementation returned for the same inputs. I managed to narrow it down to the horizontal_add operation. Here's a minimal reproduction of the issue:

cloned `simdeez` repo @ 3b78391
added the following to ./examples/f64.rs -- this untracked file is not part of this PR but made it convenient to try things.

```rust
// examples/f64.rs
use simdeez::prelude::*;
use simdeez::simd_runtime_generate;

simd_runtime_generate!(
    pub fn check_horizontal_add_f64() -> bool {
        let ones = S::Vf64::set1(1.into());
        let w = S::Vf64::WIDTH as f64;
        let resultf64 = S::Vf64::horizontal_add(ones);
        println!(
            "w: {w:.0?} ones: {ones:?} result: {resultf64} passes: {:?}",
            w == resultf64
        );
        w == resultf64
    }
);

fn main() {
    #[cfg(target_arch = "x86_64")]
    {
        println!("Checking x86_64 features:");
        println!("  SSE is supported: {:?}", is_x86_feature_detected!("sse"));
        println!(
            "  SSE2 is supported: {:?}",
            is_x86_feature_detected!("sse2")
        );
        println!("  AVX is supported: {:?}", is_x86_feature_detected!("avx"));
        println!(
            "  AVX2 is supported: {:?}",
            is_x86_feature_detected!("avx2")
        );
        println!(
            "  AVX-512F is supported: {:?}",
            is_x86_feature_detected!("avx512f")
        );
    }
    
    check_horizontal_add_f64();
    
}

```

I ran it with `cargo run --example f64`

```output
Checking x86_64 features:
  SSE is supported: true
  SSE2 is supported: true
  AVX is supported: true
  AVX2 is supported: true
  AVX-512F is supported: false
w: 4 ones: F64x4([[1.0, 1.0, 1.0, 1.0]]) result: 8 passes: false

```
We fed the horizontal_add function four ones, and it returns 8!

I'm on a Dell laptop (intel i9/x86), and this is running on ubuntu via WSL2.
```shell
~/wsl-sources/simdeez$ rustc -vV
rustc 1.88.0 (6b00bc388 2025-06-23)
binary: rustc
commit-hash: 6b00bc3880198600130e1cf62b8f8a93494488cc
commit-date: 2025-06-23
host: x86_64-unknown-linux-gnu
release: 1.88.0
LLVM version: 20.1.5
```

I started out by expanding my test to include all the supported simd instruction sets using the new `simd_unsafe_generate_all` that is analogous to the v1 `simd_runtime_generate` which makes all the variants for us. I couldn't get the macro working as is, but it looks like there's a copy/paste typo in the 'invoking.rs' file macro(s). The first commit of this PR is just a guess at what this macro was intended to do, but it made it a lot more useful to me with the patch included here, and it didn't alter your much-appreciated safety preferences. If you choose not to pull this commit in, I do hope there will be a v2 macro that is able to generate all the variants like the v1 one, it's really useful for development and sanity checks.

After that macro patch, I can re-write the reprod to show us all the simd float results for horizontal_add.

```rust
// examples/f64.rs
use simdeez::prelude::*;
use simdeez::simd_unsafe_generate_all;

simd_unsafe_generate_all!(
    pub fn check_horizontal_add_f32() -> bool {
        let ones = S::Vf32::set1(1.0);
        let w = S::Vf32::WIDTH as f32;
        let resultf32 = S::Vf32::horizontal_add(ones);
        println!(
            "w: {w:.0?} ones: {ones:?} result: {resultf32} passes: {:?}",
            w == resultf32
        );

        w == resultf32
    }
);

simd_unsafe_generate_all!(
    pub fn check_horizontal_add_f64() -> bool {
        let ones = S::Vf64::set1(1.into());
        let w = S::Vf64::WIDTH as f64;
        let resultf64 = S::Vf64::horizontal_add(ones);
        println!(
            "w: {w:.0?} ones: {ones:?} result: {resultf64} passes: {:?}",
            w == resultf64
        );
        w == resultf64
    }
);

fn main() {
    #[cfg(target_arch = "x86_64")]
    {
        println!("Checking x86_64 features:");
        println!("  SSE is supported: {:?}", is_x86_feature_detected!("sse"));
        println!(
            "  SSE2 is supported: {:?}",
            is_x86_feature_detected!("sse2")
        );
        println!("  AVX is supported: {:?}", is_x86_feature_detected!("avx"));
        println!(
            "  AVX2 is supported: {:?}",
            is_x86_feature_detected!("avx2")
        );
        println!(
            "  AVX-512F is supported: {:?}",
            is_x86_feature_detected!("avx512f")
        );
    }
    unsafe {
        check_horizontal_add_f32_scalar();
        check_horizontal_add_f32_sse2();
        check_horizontal_add_f32_sse41();
        check_horizontal_add_f32_avx2();
        check_horizontal_add_f32();
        check_horizontal_add_f64_scalar();
        check_horizontal_add_f64_sse2();
        check_horizontal_add_f64_sse41();
        check_horizontal_add_f64_avx2();
        check_horizontal_add_f64();
    }
}

```
which yields:

```output
Checking x86_64 features:
  SSE is supported: true
  SSE2 is supported: true
  AVX is supported: true
  AVX2 is supported: true
  AVX-512F is supported: false
w: 1 ones: F32x1([[1.0]]) result: 1 passes: true
w: 4 ones: F32x4([[1.0, 1.0, 1.0, 1.0]]) result: 4 passes: true
w: 4 ones: F32x4_41([[1.0, 1.0, 1.0, 1.0]]) result: 4 passes: true
w: 8 ones: F32x8([[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]]) result: 8 passes: true
w: 8 ones: F32x8([[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]]) result: 8 passes: true
w: 1 ones: F64x1([[1.0]]) result: 1 passes: true
w: 2 ones: F64x2([[1.0, 1.0]]) result: 4 passes: false
w: 2 ones: F64x2_41([[1.0, 1.0]]) result: 4 passes: false
w: 4 ones: F64x4([[1.0, 1.0, 1.0, 1.0]]) result: 8 passes: false
w: 4 ones: F64x4([[1.0, 1.0, 1.0, 1.0]]) result: 8 passes: false
```

This indicates that **all the f64 simd implementations are exactly 2x the expected result.... but all the tests pass!** What's going on?!

```shell
RUSTFLAGS='-C target-feature=+avx2,+fma' cargo test horizontal_add
```
```output
running 40 tests
test tests::run::signed_horizontal_add_scalar_f32 ... ok
test tests::run::signed_horizontal_add_scalar_i32 ... ok
test tests::run::signed_horizontal_add_scalar_i16 ... ok
test tests::run::signed_horizontal_add_scalar_f64 ... ok
...
test tests::run::unsigned_horizontal_add_sse41_i8 ... ok
test tests::run::signed_horizontal_add_avx2_i8 ... ok
test tests::run::unsigned_horizontal_add_avx2_i8 ... ok

test result: ok. 40 passed; 0 failed; 0 ignored; 0 measured; 592 filtered out; finished in 0.16s
```

These tests use an 'equals' check or an 'almost equals' check deep in the test suite, snipped here:

```rust
{ //  some larger scope that has other eq checks
        // tests/numbers.rs line 189
        match precision {
            EqPrecision::Exact => self == other,
            EqPrecision::Almost { figs } => {
                let bigger = self.max(other);
                let norm_diff = (self / bigger) - (other / bigger);
                let epsilon = 10.0f32.powi(-(figs as i32));
                norm_diff < epsilon
            }
        }
}
```

The intent here is to scale the two values and do a relative check, but there's an issue: if `self` is ever set to something small --  or to zero -- and `other` is not (say it's mistakenly doubled), then `norm_diff` will always be negative. In fact, any time that `other` is larger than self, the `norm_diff` will be negative and this check will pass -- no matter the magnitude. I did a silly `println!` in the check closure to print each result so I could inspect them... and I found out that every test is actually **1000 tests**, which is awesome, but for f64 many are 'not close' yet passing the test. Note that this check is implemented identically for the f32 tests as well.

The second commit of this PR includes a modification to this relative equality check, though I'd suggest a dev-dependency on `is_close` instead. 

This change does two things: first an absolute difference check that's less than epsilon passes early to handle the small-self issue. Then we proceed with the normalized check, but which doesn't care about the sign so much since epsilon is always positive. FWIW, this was edited to be a minimal intervention (I'm an unknown contributor after all) and this PR is already touching way to many files. I'd gladly update this PR to use `is_close` for this check if adding a dev-dependency is acceptable.

Anyway, with the update to `almost_eq`, I'm now getting test errors for f64:
```shell
RUSTFLAGS='-C target-feature=+avx2,+fma' cargo test horizontal_add
```
```output
running 40 tests
test tests::run::signed_horizontal_add_avx2_f64 ... FAILED
test tests::run::signed_horizontal_add_scalar_i16 ... ok
test tests::run::signed_horizontal_add_scalar_f64 ... ok
test tests::run::signed_horizontal_add_scalar_f32 ... ok
test tests::run::signed_horizontal_add_sse2_f64 ... FAILED
test tests::run::signed_horizontal_add_scalar_i32 ... ok
test tests::run::signed_horizontal_add_scalar_i8 ... ok
test tests::run::signed_horizontal_add_scalar_i64 ... ok
test tests::run::signed_horizontal_add_sse41_f64 ... FAILED
....
test tests::run::unsigned_horizontal_add_avx2_i8 ... ok
test tests::run::signed_horizontal_add_avx2_i8 ... ok

failures:

---- tests::run::signed_horizontal_add_avx2_f64 stdout ----

thread 'tests::run::signed_horizontal_add_avx2_f64' panicked at src/tests/lib/tester.rs:20:13:

Failed for (F64x4([[0.0, 1.0, -1.0, 0.5]]),): Failed: Expected sum to be 0.5, got 1
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- tests::run::signed_horizontal_add_sse2_f64 stdout ----

thread 'tests::run::signed_horizontal_add_sse2_f64' panicked at src/tests/lib/tester.rs:20:13:

Failed for (F64x2([[0.0, 1.0]]),): Failed: Expected sum to be 1, got 2

---- tests::run::signed_horizontal_add_sse41_f64 stdout ----

thread 'tests::run::signed_horizontal_add_sse41_f64' panicked at src/tests/lib/tester.rs:20:13:

Failed for (F64x2_41([[0.0, 1.0]]),): Failed: Expected sum to be 1, got 2


failures:
    tests::run::signed_horizontal_add_avx2_f64
    tests::run::signed_horizontal_add_sse2_f64
    tests::run::signed_horizontal_add_sse41_f64

test result: FAILED. 37 passed; 3 failed; 0 ignored; 0 measured; 592 filtered out; finished in 0.16s

```

Note that, despite changing the `almost_eq` implementation significantly, the _only_ failures are with simd implementations of f64s. Awesome. 

The third commit in this PR includes adjustments to the avx2, sse2, sse41, and Neon implementations for f64 (I set up actions on my fork and also noticed that neon was affected by this issue too!), and now all the tests pass CI (including neon). The issue with the v2 implementations for f64 horizontal_add seemed to be too many instructions, as though the author thought twice as many f64s needed to be reduced for each instruction set (an easy mistake to make with the correct f32 implementations as reference). For this PR I did not spend time 'optimizing' these instruction sequences, my focus was on minimal intervention and correctness. 

Thanks for maintaining this crate and for reviewing this PR, and apologies for the long-winded writeup!