### PR TITLE
Base Performance Benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,17 +40,5 @@ default-features = false
 features = ["plotters", "cargo_bench_support"]
 
 [[bench]]
-name = "numparse"
-harness = false
-
-[[bench]]
-name = "horizontal_add"
-harness = false
-
-[[bench]]
-name = "int_ops"
-harness = false
-
-[[bench]]
-name = "float_rounding"
+name = "bench_main"
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,15 @@ features = ["plotters", "cargo_bench_support"]
 [[bench]]
 name = "numparse"
 harness = false
+
+[[bench]]
+name = "horizontal_add"
+harness = false
+
+[[bench]]
+name = "int_ops"
+harness = false
+
+[[bench]]
+name = "float_rounding"
+harness = false

--- a/benches/bench_main.rs
+++ b/benches/bench_main.rs
@@ -1,0 +1,13 @@
+mod float_rounding;
+mod horizontal_add;
+mod int_ops;
+mod numparse;
+
+use criterion::criterion_main;
+
+criterion_main!(
+    float_rounding::benches,
+    horizontal_add::benches,
+    int_ops::benches,
+    numparse::benches,
+);

--- a/benches/float_rounding.rs
+++ b/benches/float_rounding.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, Criterion};
 use simdeez::prelude::*;
 
 // --- f32 floor ---
@@ -57,6 +57,20 @@ simd_unsafe_generate_all!(
     }
 );
 
+// --- f64 cast_i64 ---
+
+simd_unsafe_generate_all!(
+    fn bench_f64_cast_i64(data: &[f64], out: &mut [i64]) {
+        let chunks = data.len() / S::Vf64::WIDTH;
+        for i in 0..chunks {
+            let offset = i * S::Vf64::WIDTH;
+            let v = S::Vf64::load_from_slice(&data[offset..]);
+            let result = v.cast_i64();
+            result.copy_to_slice(&mut out[offset..]);
+        }
+    }
+);
+
 fn criterion_benchmark(c: &mut Criterion) {
     let size = 32768;
 
@@ -66,50 +80,60 @@ fn criterion_benchmark(c: &mut Criterion) {
     let f64_data: Vec<f64> = (0..size).map(|i| (i as f64) * 0.1 - 1000.0).collect();
     let mut f64_out = vec![0.0f64; size];
 
+    let mut g = c.benchmark_group("float_rounding");
+
     // f32 floor
-    c.bench_function("f32 floor sse2", |b| {
+    g.bench_function("f32 floor sse2", |b| {
         b.iter(|| unsafe { bench_f32_floor_sse2(&f32_data, &mut f32_out) })
     });
-    c.bench_function("f32 floor sse41", |b| {
+    g.bench_function("f32 floor sse41", |b| {
         b.iter(|| unsafe { bench_f32_floor_sse41(&f32_data, &mut f32_out) })
     });
-    c.bench_function("f32 floor avx2", |b| {
+    g.bench_function("f32 floor avx2", |b| {
         b.iter(|| unsafe { bench_f32_floor_avx2(&f32_data, &mut f32_out) })
     });
 
     // f32 ceil
-    c.bench_function("f32 ceil sse2", |b| {
+    g.bench_function("f32 ceil sse2", |b| {
         b.iter(|| unsafe { bench_f32_ceil_sse2(&f32_data, &mut f32_out) })
     });
-    c.bench_function("f32 ceil sse41", |b| {
+    g.bench_function("f32 ceil sse41", |b| {
         b.iter(|| unsafe { bench_f32_ceil_sse41(&f32_data, &mut f32_out) })
     });
-    c.bench_function("f32 ceil avx2", |b| {
+    g.bench_function("f32 ceil avx2", |b| {
         b.iter(|| unsafe { bench_f32_ceil_avx2(&f32_data, &mut f32_out) })
     });
 
     // f64 floor
-    c.bench_function("f64 floor sse2", |b| {
+    g.bench_function("f64 floor sse2", |b| {
         b.iter(|| unsafe { bench_f64_floor_sse2(&f64_data, &mut f64_out) })
     });
-    c.bench_function("f64 floor sse41", |b| {
+    g.bench_function("f64 floor sse41", |b| {
         b.iter(|| unsafe { bench_f64_floor_sse41(&f64_data, &mut f64_out) })
     });
-    c.bench_function("f64 floor avx2", |b| {
+    g.bench_function("f64 floor avx2", |b| {
         b.iter(|| unsafe { bench_f64_floor_avx2(&f64_data, &mut f64_out) })
     });
 
     // f64 ceil
-    c.bench_function("f64 ceil sse2", |b| {
+    g.bench_function("f64 ceil sse2", |b| {
         b.iter(|| unsafe { bench_f64_ceil_sse2(&f64_data, &mut f64_out) })
     });
-    c.bench_function("f64 ceil sse41", |b| {
+    g.bench_function("f64 ceil sse41", |b| {
         b.iter(|| unsafe { bench_f64_ceil_sse41(&f64_data, &mut f64_out) })
     });
-    c.bench_function("f64 ceil avx2", |b| {
+    g.bench_function("f64 ceil avx2", |b| {
         b.iter(|| unsafe { bench_f64_ceil_avx2(&f64_data, &mut f64_out) })
+    });
+
+    // f64 cast_i64
+    let mut i64_out = vec![0i64; size];
+    g.bench_function("f64 cast_i64 sse41", |b| {
+        b.iter(|| unsafe { bench_f64_cast_i64_sse41(&f64_data, &mut i64_out) })
+    });
+    g.bench_function("f64 cast_i64 avx2", |b| {
+        b.iter(|| unsafe { bench_f64_cast_i64_avx2(&f64_data, &mut i64_out) })
     });
 }
 
 criterion_group!(benches, criterion_benchmark);
-criterion_main!(benches);

--- a/benches/float_rounding.rs
+++ b/benches/float_rounding.rs
@@ -1,0 +1,115 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use simdeez::prelude::*;
+
+// --- f32 floor ---
+
+simd_unsafe_generate_all!(
+    fn bench_f32_floor(data: &[f32], out: &mut [f32]) {
+        let chunks = data.len() / S::Vf32::WIDTH;
+        for i in 0..chunks {
+            let offset = i * S::Vf32::WIDTH;
+            let v = S::Vf32::load_from_slice(&data[offset..]);
+            let result = v.floor();
+            result.copy_to_slice(&mut out[offset..]);
+        }
+    }
+);
+
+// --- f32 ceil ---
+
+simd_unsafe_generate_all!(
+    fn bench_f32_ceil(data: &[f32], out: &mut [f32]) {
+        let chunks = data.len() / S::Vf32::WIDTH;
+        for i in 0..chunks {
+            let offset = i * S::Vf32::WIDTH;
+            let v = S::Vf32::load_from_slice(&data[offset..]);
+            let result = v.ceil();
+            result.copy_to_slice(&mut out[offset..]);
+        }
+    }
+);
+
+// --- f64 floor ---
+
+simd_unsafe_generate_all!(
+    fn bench_f64_floor(data: &[f64], out: &mut [f64]) {
+        let chunks = data.len() / S::Vf64::WIDTH;
+        for i in 0..chunks {
+            let offset = i * S::Vf64::WIDTH;
+            let v = S::Vf64::load_from_slice(&data[offset..]);
+            let result = v.floor();
+            result.copy_to_slice(&mut out[offset..]);
+        }
+    }
+);
+
+// --- f64 ceil ---
+
+simd_unsafe_generate_all!(
+    fn bench_f64_ceil(data: &[f64], out: &mut [f64]) {
+        let chunks = data.len() / S::Vf64::WIDTH;
+        for i in 0..chunks {
+            let offset = i * S::Vf64::WIDTH;
+            let v = S::Vf64::load_from_slice(&data[offset..]);
+            let result = v.ceil();
+            result.copy_to_slice(&mut out[offset..]);
+        }
+    }
+);
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let size = 32768;
+
+    let f32_data: Vec<f32> = (0..size).map(|i| (i as f32) * 0.1 - 1000.0).collect();
+    let mut f32_out = vec![0.0f32; size];
+
+    let f64_data: Vec<f64> = (0..size).map(|i| (i as f64) * 0.1 - 1000.0).collect();
+    let mut f64_out = vec![0.0f64; size];
+
+    // f32 floor
+    c.bench_function("f32 floor sse2", |b| {
+        b.iter(|| unsafe { bench_f32_floor_sse2(&f32_data, &mut f32_out) })
+    });
+    c.bench_function("f32 floor sse41", |b| {
+        b.iter(|| unsafe { bench_f32_floor_sse41(&f32_data, &mut f32_out) })
+    });
+    c.bench_function("f32 floor avx2", |b| {
+        b.iter(|| unsafe { bench_f32_floor_avx2(&f32_data, &mut f32_out) })
+    });
+
+    // f32 ceil
+    c.bench_function("f32 ceil sse2", |b| {
+        b.iter(|| unsafe { bench_f32_ceil_sse2(&f32_data, &mut f32_out) })
+    });
+    c.bench_function("f32 ceil sse41", |b| {
+        b.iter(|| unsafe { bench_f32_ceil_sse41(&f32_data, &mut f32_out) })
+    });
+    c.bench_function("f32 ceil avx2", |b| {
+        b.iter(|| unsafe { bench_f32_ceil_avx2(&f32_data, &mut f32_out) })
+    });
+
+    // f64 floor
+    c.bench_function("f64 floor sse2", |b| {
+        b.iter(|| unsafe { bench_f64_floor_sse2(&f64_data, &mut f64_out) })
+    });
+    c.bench_function("f64 floor sse41", |b| {
+        b.iter(|| unsafe { bench_f64_floor_sse41(&f64_data, &mut f64_out) })
+    });
+    c.bench_function("f64 floor avx2", |b| {
+        b.iter(|| unsafe { bench_f64_floor_avx2(&f64_data, &mut f64_out) })
+    });
+
+    // f64 ceil
+    c.bench_function("f64 ceil sse2", |b| {
+        b.iter(|| unsafe { bench_f64_ceil_sse2(&f64_data, &mut f64_out) })
+    });
+    c.bench_function("f64 ceil sse41", |b| {
+        b.iter(|| unsafe { bench_f64_ceil_sse41(&f64_data, &mut f64_out) })
+    });
+    c.bench_function("f64 ceil avx2", |b| {
+        b.iter(|| unsafe { bench_f64_ceil_avx2(&f64_data, &mut f64_out) })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/horizontal_add.rs
+++ b/benches/horizontal_add.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, Criterion};
 use simdeez::prelude::*;
 
 simd_unsafe_generate_all!(
@@ -31,20 +31,21 @@ fn criterion_benchmark(c: &mut Criterion) {
     let f32_data: Vec<f32> = (0..32768).map(|i| (i as f32) * 0.1).collect();
     let f64_data: Vec<f64> = (0..32768).map(|i| (i as f64) * 0.1).collect();
 
-    c.bench_function("horizontal_add f32 sse41", |b| {
+    let mut g = c.benchmark_group("horizontal_add");
+
+    g.bench_function("horizontal_add f32 sse41", |b| {
         b.iter(|| unsafe { bench_horizontal_add_f32_sse41(&f32_data) })
     });
-    c.bench_function("horizontal_add f32 avx2", |b| {
+    g.bench_function("horizontal_add f32 avx2", |b| {
         b.iter(|| unsafe { bench_horizontal_add_f32_avx2(&f32_data) })
     });
 
-    c.bench_function("horizontal_add f64 sse41", |b| {
+    g.bench_function("horizontal_add f64 sse41", |b| {
         b.iter(|| unsafe { bench_horizontal_add_f64_sse41(&f64_data) })
     });
-    c.bench_function("horizontal_add f64 avx2", |b| {
+    g.bench_function("horizontal_add f64 avx2", |b| {
         b.iter(|| unsafe { bench_horizontal_add_f64_avx2(&f64_data) })
     });
 }
 
 criterion_group!(benches, criterion_benchmark);
-criterion_main!(benches);

--- a/benches/horizontal_add.rs
+++ b/benches/horizontal_add.rs
@@ -1,0 +1,50 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use simdeez::prelude::*;
+
+simd_unsafe_generate_all!(
+    fn bench_horizontal_add_f32(data: &[f32]) -> f32 {
+        let mut sum = 0.0f32;
+        let chunks = data.len() / S::Vf32::WIDTH;
+        for i in 0..chunks {
+            let offset = i * S::Vf32::WIDTH;
+            let v = S::Vf32::load_from_slice(&data[offset..]);
+            sum += v.horizontal_add();
+        }
+        sum
+    }
+);
+
+simd_unsafe_generate_all!(
+    fn bench_horizontal_add_f64(data: &[f64]) -> f64 {
+        let mut sum = 0.0f64;
+        let chunks = data.len() / S::Vf64::WIDTH;
+        for i in 0..chunks {
+            let offset = i * S::Vf64::WIDTH;
+            let v = S::Vf64::load_from_slice(&data[offset..]);
+            sum += v.horizontal_add();
+        }
+        sum
+    }
+);
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let f32_data: Vec<f32> = (0..32768).map(|i| (i as f32) * 0.1).collect();
+    let f64_data: Vec<f64> = (0..32768).map(|i| (i as f64) * 0.1).collect();
+
+    c.bench_function("horizontal_add f32 sse41", |b| {
+        b.iter(|| unsafe { bench_horizontal_add_f32_sse41(&f32_data) })
+    });
+    c.bench_function("horizontal_add f32 avx2", |b| {
+        b.iter(|| unsafe { bench_horizontal_add_f32_avx2(&f32_data) })
+    });
+
+    c.bench_function("horizontal_add f64 sse41", |b| {
+        b.iter(|| unsafe { bench_horizontal_add_f64_sse41(&f64_data) })
+    });
+    c.bench_function("horizontal_add f64 avx2", |b| {
+        b.iter(|| unsafe { bench_horizontal_add_f64_avx2(&f64_data) })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/int_ops.rs
+++ b/benches/int_ops.rs
@@ -1,0 +1,155 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use simdeez::prelude::*;
+
+// --- i8 multiply ---
+
+simd_unsafe_generate_all!(
+    fn bench_i8_mul(a: &[i8], b: &[i8], out: &mut [i8]) {
+        let chunks = a.len() / S::Vi8::WIDTH;
+        for i in 0..chunks {
+            let offset = i * S::Vi8::WIDTH;
+            let va = S::Vi8::load_from_slice(&a[offset..]);
+            let vb = S::Vi8::load_from_slice(&b[offset..]);
+            let result = va * vb;
+            result.copy_to_slice(&mut out[offset..]);
+        }
+    }
+);
+
+// --- i8 less-than ---
+
+simd_unsafe_generate_all!(
+    fn bench_i8_lt(a: &[i8], b: &[i8], out: &mut [i8]) {
+        let chunks = a.len() / S::Vi8::WIDTH;
+        for i in 0..chunks {
+            let offset = i * S::Vi8::WIDTH;
+            let va = S::Vi8::load_from_slice(&a[offset..]);
+            let vb = S::Vi8::load_from_slice(&b[offset..]);
+            let result = va.cmp_lt(vb);
+            result.copy_to_slice(&mut out[offset..]);
+        }
+    }
+);
+
+// --- i16 less-than ---
+
+simd_unsafe_generate_all!(
+    fn bench_i16_lt(a: &[i16], b: &[i16], out: &mut [i16]) {
+        let chunks = a.len() / S::Vi16::WIDTH;
+        for i in 0..chunks {
+            let offset = i * S::Vi16::WIDTH;
+            let va = S::Vi16::load_from_slice(&a[offset..]);
+            let vb = S::Vi16::load_from_slice(&b[offset..]);
+            let result = va.cmp_lt(vb);
+            result.copy_to_slice(&mut out[offset..]);
+        }
+    }
+);
+
+// --- i32 less-than ---
+
+simd_unsafe_generate_all!(
+    fn bench_i32_lt(a: &[i32], b: &[i32], out: &mut [i32]) {
+        let chunks = a.len() / S::Vi32::WIDTH;
+        for i in 0..chunks {
+            let offset = i * S::Vi32::WIDTH;
+            let va = S::Vi32::load_from_slice(&a[offset..]);
+            let vb = S::Vi32::load_from_slice(&b[offset..]);
+            let result = va.cmp_lt(vb);
+            result.copy_to_slice(&mut out[offset..]);
+        }
+    }
+);
+
+// --- i64 less-than ---
+
+simd_unsafe_generate_all!(
+    fn bench_i64_lt(a: &[i64], b: &[i64], out: &mut [i64]) {
+        let chunks = a.len() / S::Vi64::WIDTH;
+        for i in 0..chunks {
+            let offset = i * S::Vi64::WIDTH;
+            let va = S::Vi64::load_from_slice(&a[offset..]);
+            let vb = S::Vi64::load_from_slice(&b[offset..]);
+            let result = va.cmp_lt(vb);
+            result.copy_to_slice(&mut out[offset..]);
+        }
+    }
+);
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let size = 32768;
+
+    let i8_a: Vec<i8> = (0..size).map(|i| (i % 127) as i8).collect();
+    let i8_b: Vec<i8> = (0..size).map(|i| ((i * 3) % 127) as i8).collect();
+    let mut i8_out = vec![0i8; size];
+
+    let i16_a: Vec<i16> = (0..size).map(|i| (i % 32000) as i16).collect();
+    let i16_b: Vec<i16> = (0..size).map(|i| ((i * 3) % 32000) as i16).collect();
+    let mut i16_out = vec![0i16; size];
+
+    let i32_a: Vec<i32> = (0..size).map(|i| i as i32).collect();
+    let i32_b: Vec<i32> = (0..size).map(|i| (i as i32).wrapping_mul(3)).collect();
+    let mut i32_out = vec![0i32; size];
+
+    let i64_a: Vec<i64> = (0..size).map(|i| i as i64).collect();
+    let i64_b: Vec<i64> = (0..size).map(|i| (i as i64).wrapping_mul(3)).collect();
+    let mut i64_out = vec![0i64; size];
+
+    // i8 mul
+    c.bench_function("i8 mul sse2", |b| {
+        b.iter(|| unsafe { bench_i8_mul_sse2(&i8_a, &i8_b, &mut i8_out) })
+    });
+    c.bench_function("i8 mul sse41", |b| {
+        b.iter(|| unsafe { bench_i8_mul_sse41(&i8_a, &i8_b, &mut i8_out) })
+    });
+    c.bench_function("i8 mul avx2", |b| {
+        b.iter(|| unsafe { bench_i8_mul_avx2(&i8_a, &i8_b, &mut i8_out) })
+    });
+
+    // i8 lt
+    c.bench_function("i8 lt sse2", |b| {
+        b.iter(|| unsafe { bench_i8_lt_sse2(&i8_a, &i8_b, &mut i8_out) })
+    });
+    c.bench_function("i8 lt sse41", |b| {
+        b.iter(|| unsafe { bench_i8_lt_sse41(&i8_a, &i8_b, &mut i8_out) })
+    });
+    c.bench_function("i8 lt avx2", |b| {
+        b.iter(|| unsafe { bench_i8_lt_avx2(&i8_a, &i8_b, &mut i8_out) })
+    });
+
+    // i16 lt
+    c.bench_function("i16 lt sse2", |b| {
+        b.iter(|| unsafe { bench_i16_lt_sse2(&i16_a, &i16_b, &mut i16_out) })
+    });
+    c.bench_function("i16 lt sse41", |b| {
+        b.iter(|| unsafe { bench_i16_lt_sse41(&i16_a, &i16_b, &mut i16_out) })
+    });
+    c.bench_function("i16 lt avx2", |b| {
+        b.iter(|| unsafe { bench_i16_lt_avx2(&i16_a, &i16_b, &mut i16_out) })
+    });
+
+    // i32 lt
+    c.bench_function("i32 lt sse2", |b| {
+        b.iter(|| unsafe { bench_i32_lt_sse2(&i32_a, &i32_b, &mut i32_out) })
+    });
+    c.bench_function("i32 lt sse41", |b| {
+        b.iter(|| unsafe { bench_i32_lt_sse41(&i32_a, &i32_b, &mut i32_out) })
+    });
+    c.bench_function("i32 lt avx2", |b| {
+        b.iter(|| unsafe { bench_i32_lt_avx2(&i32_a, &i32_b, &mut i32_out) })
+    });
+
+    // i64 lt
+    c.bench_function("i64 lt sse2", |b| {
+        b.iter(|| unsafe { bench_i64_lt_sse2(&i64_a, &i64_b, &mut i64_out) })
+    });
+    c.bench_function("i64 lt sse41", |b| {
+        b.iter(|| unsafe { bench_i64_lt_sse41(&i64_a, &i64_b, &mut i64_out) })
+    });
+    c.bench_function("i64 lt avx2", |b| {
+        b.iter(|| unsafe { bench_i64_lt_avx2(&i64_a, &i64_b, &mut i64_out) })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/int_ops.rs
+++ b/benches/int_ops.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, Criterion};
 use simdeez::prelude::*;
 
 // --- i8 multiply ---
@@ -95,61 +95,62 @@ fn criterion_benchmark(c: &mut Criterion) {
     let i64_b: Vec<i64> = (0..size).map(|i| (i as i64).wrapping_mul(3)).collect();
     let mut i64_out = vec![0i64; size];
 
+    let mut g = c.benchmark_group("int_ops");
+
     // i8 mul
-    c.bench_function("i8 mul sse2", |b| {
+    g.bench_function("i8 mul sse2", |b| {
         b.iter(|| unsafe { bench_i8_mul_sse2(&i8_a, &i8_b, &mut i8_out) })
     });
-    c.bench_function("i8 mul sse41", |b| {
+    g.bench_function("i8 mul sse41", |b| {
         b.iter(|| unsafe { bench_i8_mul_sse41(&i8_a, &i8_b, &mut i8_out) })
     });
-    c.bench_function("i8 mul avx2", |b| {
+    g.bench_function("i8 mul avx2", |b| {
         b.iter(|| unsafe { bench_i8_mul_avx2(&i8_a, &i8_b, &mut i8_out) })
     });
 
     // i8 lt
-    c.bench_function("i8 lt sse2", |b| {
+    g.bench_function("i8 lt sse2", |b| {
         b.iter(|| unsafe { bench_i8_lt_sse2(&i8_a, &i8_b, &mut i8_out) })
     });
-    c.bench_function("i8 lt sse41", |b| {
+    g.bench_function("i8 lt sse41", |b| {
         b.iter(|| unsafe { bench_i8_lt_sse41(&i8_a, &i8_b, &mut i8_out) })
     });
-    c.bench_function("i8 lt avx2", |b| {
+    g.bench_function("i8 lt avx2", |b| {
         b.iter(|| unsafe { bench_i8_lt_avx2(&i8_a, &i8_b, &mut i8_out) })
     });
 
     // i16 lt
-    c.bench_function("i16 lt sse2", |b| {
+    g.bench_function("i16 lt sse2", |b| {
         b.iter(|| unsafe { bench_i16_lt_sse2(&i16_a, &i16_b, &mut i16_out) })
     });
-    c.bench_function("i16 lt sse41", |b| {
+    g.bench_function("i16 lt sse41", |b| {
         b.iter(|| unsafe { bench_i16_lt_sse41(&i16_a, &i16_b, &mut i16_out) })
     });
-    c.bench_function("i16 lt avx2", |b| {
+    g.bench_function("i16 lt avx2", |b| {
         b.iter(|| unsafe { bench_i16_lt_avx2(&i16_a, &i16_b, &mut i16_out) })
     });
 
     // i32 lt
-    c.bench_function("i32 lt sse2", |b| {
+    g.bench_function("i32 lt sse2", |b| {
         b.iter(|| unsafe { bench_i32_lt_sse2(&i32_a, &i32_b, &mut i32_out) })
     });
-    c.bench_function("i32 lt sse41", |b| {
+    g.bench_function("i32 lt sse41", |b| {
         b.iter(|| unsafe { bench_i32_lt_sse41(&i32_a, &i32_b, &mut i32_out) })
     });
-    c.bench_function("i32 lt avx2", |b| {
+    g.bench_function("i32 lt avx2", |b| {
         b.iter(|| unsafe { bench_i32_lt_avx2(&i32_a, &i32_b, &mut i32_out) })
     });
 
     // i64 lt
-    c.bench_function("i64 lt sse2", |b| {
+    g.bench_function("i64 lt sse2", |b| {
         b.iter(|| unsafe { bench_i64_lt_sse2(&i64_a, &i64_b, &mut i64_out) })
     });
-    c.bench_function("i64 lt sse41", |b| {
+    g.bench_function("i64 lt sse41", |b| {
         b.iter(|| unsafe { bench_i64_lt_sse41(&i64_a, &i64_b, &mut i64_out) })
     });
-    c.bench_function("i64 lt avx2", |b| {
+    g.bench_function("i64 lt avx2", |b| {
         b.iter(|| unsafe { bench_i64_lt_avx2(&i64_a, &i64_b, &mut i64_out) })
     });
 }
 
 criterion_group!(benches, criterion_benchmark);
-criterion_main!(benches);

--- a/benches/numparse.rs
+++ b/benches/numparse.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, Criterion};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use simdeez::{prelude::*, simd_runtime_generate};
@@ -195,4 +195,3 @@ fn criterion_benchmark(c: &mut Criterion) {
 }
 
 criterion_group!(benches, criterion_benchmark);
-criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,32 +187,32 @@ pub trait Simd: 'static + Sync + Send {
     /// Vector of i8s.  Corresponds to __m128i when used
     /// with the Sse impl, __m256i when used with Avx2, or a single i8
     /// when used with Scalar.
-    type Vi8: SimdInt8<Scalar = i8> + SimdBaseIo;
+    type Vi8: SimdInt8<Scalar = i8> + SimdBaseIo + SimdConsts<Scalar = i8>;
 
     /// Vector of i16s.  Corresponds to __m128i when used
     /// with the Sse impl, __m256i when used with Avx2, or a single i16
     /// when used with Scalar.
-    type Vi16: SimdInt16<Scalar = i16> + SimdBaseIo;
+    type Vi16: SimdInt16<Scalar = i16> + SimdBaseIo + SimdConsts<Scalar = i16>;
 
     /// Vector of i32s.  Corresponds to __m128i when used
     /// with the Sse impl, __m256i when used with Avx2, or a single i32
     /// when used with Scalar.
-    type Vi32: SimdInt32<Engine = Self, Scalar = i32> + SimdBaseIo;
+    type Vi32: SimdInt32<Engine = Self, Scalar = i32> + SimdBaseIo + SimdConsts<Scalar = i32>;
 
     /// Vector of i64s.  Corresponds to __m128i when used
     /// with the Sse impl, __m256i when used with Avx2, or a single i64
     /// when used with Scalar.
-    type Vi64: SimdInt64<Engine = Self, Scalar = i64> + SimdBaseIo;
+    type Vi64: SimdInt64<Engine = Self, Scalar = i64> + SimdBaseIo + SimdConsts<Scalar = i64>;
 
     /// Vector of f32s.  Corresponds to __m128 when used
     /// with the Sse impl, __m256 when used with Avx2, or a single f32
     /// when used with Scalar.
-    type Vf32: SimdFloat32<Engine = Self, Scalar = f32> + SimdBaseIo;
+    type Vf32: SimdFloat32<Engine = Self, Scalar = f32> + SimdBaseIo + SimdConsts<Scalar = f32>;
 
     /// Vector of f64s.  Corresponds to __m128d when used
     /// with the Sse impl, __m256d when used with Avx2, or a single f64
     /// when used with Scalar.
-    type Vf64: SimdFloat64<Engine = Self, Scalar = f64> + SimdBaseIo;
+    type Vf64: SimdFloat64<Engine = Self, Scalar = f64> + SimdBaseIo + SimdConsts<Scalar = f64>;
 
     // The width of the vector lane.  Necessary for creating
     // lane width agnostic code.


### PR DESCRIPTION
this refactored bench suite is not meant to be pushed upstream. It's just here for reference by the upstream maintainers.

Requires x86 arch with support for sse2, sse41, and avx2 or will panic.

Workflow i used for benching other PRs:
1. add to a branch based on the release commit of `simdeez` v2.0.0.
2. capture a baseline for v2 with `cargo bench --bench bench_main -- "float_rounding|int_ops|horizontal_add" --save-baseline baseline`
3. add each linked PR in turn and rerun benches with `cargo bench --bench bench_main -- "float_rounding|int_ops|horizontal_add" --baseline baseline` to see incremental performance improvement
