### PR TITLE
Optimize Float floor and ceil

### DIFF
--- a/src/ops/f32.rs
+++ b/src/ops/f32.rs
@@ -363,14 +363,10 @@ impl_op! {
             _mm_round_ps(a, _MM_FROUND_TO_NEG_INF | _MM_FROUND_NO_EXC)
         }
         for Sse2(a: __m128) -> __m128 {
-            let nums_arr = core::mem::transmute::<__m128, [f32; 4]>(a);
-            let ceil = [
-                nums_arr[0].m_floor(),
-                nums_arr[1].m_floor(),
-                nums_arr[2].m_floor(),
-                nums_arr[3].m_floor(),
-            ];
-            core::mem::transmute::<[f32; 4], __m128>(ceil)
+            let rounded = Ops::<Sse2, f32>::round(a);
+            let mask = _mm_cmpgt_ps(rounded, a);
+            let one = _mm_and_ps(mask, _mm_set1_ps(1.0));
+            _mm_sub_ps(rounded, one)
         }
         for Scalar(a: f32) -> f32 {
             a.m_floor()
@@ -393,14 +389,10 @@ impl_op! {
             _mm_round_ps(a, _MM_FROUND_TO_POS_INF | _MM_FROUND_NO_EXC)
         }
         for Sse2(a: __m128) -> __m128 {
-            let nums_arr = core::mem::transmute::<__m128, [f32; 4]>(a);
-            let ceil = [
-                nums_arr[0].m_ceil(),
-                nums_arr[1].m_ceil(),
-                nums_arr[2].m_ceil(),
-                nums_arr[3].m_ceil(),
-            ];
-            core::mem::transmute::<[f32; 4], __m128>(ceil)
+            let rounded = Ops::<Sse2, f32>::round(a);
+            let mask = _mm_cmplt_ps(rounded, a);
+            let one = _mm_and_ps(mask, _mm_set1_ps(1.0));
+            _mm_add_ps(rounded, one)
         }
         for Scalar(a: f32) -> f32 {
             a.m_ceil()

--- a/src/ops/f64.rs
+++ b/src/ops/f64.rs
@@ -345,12 +345,10 @@ impl_op! {
             _mm_round_pd(a, _MM_FROUND_TO_NEG_INF | _MM_FROUND_NO_EXC)
         }
         for Sse2(a: __m128d) -> __m128d {
-            let nums_arr = core::mem::transmute::<__m128d, [f64; 2]>(a);
-            let ceil = [
-                nums_arr[0].m_floor(),
-                nums_arr[1].m_floor(),
-            ];
-            core::mem::transmute::<[f64; 2], __m128d>(ceil)
+            let rounded = Ops::<Sse2, f64>::round(a);
+            let mask = _mm_cmpgt_pd(rounded, a);
+            let one = _mm_and_pd(mask, _mm_set1_pd(1.0));
+            _mm_sub_pd(rounded, one)
         }
         for Scalar(a: f64) -> f64 {
             a.m_floor()
@@ -373,12 +371,10 @@ impl_op! {
             _mm_round_pd(a, _MM_FROUND_TO_POS_INF | _MM_FROUND_NO_EXC)
         }
         for Sse2(a: __m128d) -> __m128d {
-            let nums_arr = core::mem::transmute::<__m128d, [f64; 2]>(a);
-            let ceil = [
-                nums_arr[0].m_ceil(),
-                nums_arr[1].m_ceil(),
-            ];
-            core::mem::transmute::<[f64; 2], __m128d>(ceil)
+            let rounded = Ops::<Sse2, f64>::round(a);
+            let mask = _mm_cmplt_pd(rounded, a);
+            let one = _mm_and_pd(mask, _mm_set1_pd(1.0));
+            _mm_add_pd(rounded, one)
         }
         for Scalar(a: f64) -> f64 {
             a.m_ceil()


### PR DESCRIPTION
Hi, this is the first of a few PRs that I've teed up that have shown some performance improvements. I've tried to keep these simple and standalone so that they're easy to review independently of one another rather than stacking them all up into one PR (though i'd be happy to close these and submit as one PR if you prefer).

This one includes very minor changes to the float `floor` and `ceil` implementations for f32 and f64 with SSE2 that uses the rounding intrinsic instead of the transmute+scalar+transmute approach.

These yield nice performance gains though:
* f32 floor SSE2 -88% (8x faster)
* f32 ceil SSE2 -87%
* f64 floor SSE2 -82%
* f64 ceil SSE2 -79%

These were benchmarked with the benches saved here: https://github.com/austinorr/simdeez/pull/4

use this command if you've saved a v2 baseline already.
`cargo bench --bench bench_main -- "float_rounding" --baseline baseline`